### PR TITLE
fix(ansible_role_find_empty_directories): skip hidden directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Have all checks run:
 ```yaml
 repos:
    - repo: https://github.com/robertdebock/pre-commit
-     rev: v1.4.4
+     rev: v1.4.5
      hooks:
        - id: ansible_role_find_unused_variable
        - id: ansible_role_find_empty_files
@@ -28,7 +28,7 @@ Expand (or create) your `.pre-commit-config.yml` with this section:
 ```yaml
 repos:
   - repo: https://github.com/robertdebock/pre-commit
-    rev: v1.4.4
+    rev: v1.4.5
     hooks:
       - id: ansible_role_find_unused_variable
 ```
@@ -40,7 +40,7 @@ This hook can find empty `defaults/main.yml`, `handlers/main.yml` and `vars/main
 ```yaml
 repos:
   - repo: https://github.com/robertdebock/pre-commit
-    rev: v1.4.4
+    rev: v1.4.5
     hooks:
       - id: ansible_role_find_empty_files
 ```
@@ -52,7 +52,7 @@ This hook can find empty directories.
 ```yaml
 repos:
   - repo: https://github.com/robertdebock/pre-commit
-    rev: v1.4.4
+    rev: v1.4.5
     hooks:
       - id: ansible_role_find_empty_directory
 ```
@@ -64,7 +64,7 @@ This hook can improve readability.
 ```yaml
 repos:
   - repo: https://github.com/robertdebock/pre-commit
-    rev: v1.4.4
+    rev: v1.4.5
     hooks:
       - id: ansible_role_fix_readability
 ```
@@ -76,7 +76,7 @@ This hook can find undefined handlers.
 ```yaml
 repos:
   - repo: https://github.com/robertdebock/pre-commit
-    rev: v1.4.4
+    rev: v1.4.5
     hooks:
       - id: ansible_role_find_undefined_handlers
 ```
@@ -88,7 +88,7 @@ This hook can find unquoted values.
 ```yaml
 repos:
   - repo: https://github.com/robertdebock/pre-commit
-    rev: v1.4.4
+    rev: v1.4.5
     hooks:
       - id: ansible_role_find_unquoted_values
 ```

--- a/ansible_role_find_empty_directories.sh
+++ b/ansible_role_find_empty_directories.sh
@@ -12,6 +12,6 @@ checker() {
   fi
 }
 
-find ./ -maxdepth 1 -type d | while read -r dir ; do
+find ./ -maxdepth 1 -type d -not -name '.*' | while read -r dir ; do
   checker "$dir"
 done


### PR DESCRIPTION
speed up the scanning by skipping hidden directories like: .tox, .cache, etc.